### PR TITLE
fix: erro de descrição longa com utf8

### DIFF
--- a/src/rn/ExpedirProcedimentoRN.php
+++ b/src/rn/ExpedirProcedimentoRN.php
@@ -1726,17 +1726,17 @@ class ExpedirProcedimentoRN extends InfraRN {
           $objDocumento->identificacao = new stdClass();
           $objDocumento->identificacao->numero = utf8_encode($parObjDocumentoDTO->getStrNumero());
           $objDocumento->identificacao->siglaDaUnidadeProdutora = utf8_encode($parObjDocumentoDTO->getStrSiglaUnidadeGeradoraProtocolo());
-          $objDocumento->identificacao->complemento = $this->objProcessoEletronicoRN->reduzirCampoTexto(utf8_encode($parObjDocumentoDTO->getStrDescricaoUnidadeGeradoraProtocolo()), 100);
+          $objDocumento->identificacao->complemento = utf8_encode($this->objProcessoEletronicoRN->reduzirCampoTexto($parObjDocumentoDTO->getStrDescricaoUnidadeGeradoraProtocolo(), 100));
       }else if($strStaNumeracao == SerieRN::$TN_SEQUENCIAL_ORGAO){
           $objOrgaoDTO = $this->consultarOrgao($parObjDocumentoDTO->getNumIdOrgaoUnidadeGeradoraProtocolo());
           $objDocumento->identificacao = new stdClass();
           $objDocumento->identificacao->numero = utf8_encode($parObjDocumentoDTO->getStrNumero());
           $objDocumento->identificacao->siglaDaUnidadeProdutora = utf8_encode($objOrgaoDTO->getStrSigla());
-          $objDocumento->identificacao->complemento = $this->objProcessoEletronicoRN->reduzirCampoTexto(utf8_encode($objOrgaoDTO->getStrDescricao()), 100);
+          $objDocumento->identificacao->complemento = utf8_encode($this->objProcessoEletronicoRN->reduzirCampoTexto($objOrgaoDTO->getStrDescricao(), 100));
       }else if($strStaNumeracao == SerieRN::$TN_SEQUENCIAL_ANUAL_UNIDADE){
           $objDocumento->identificacao = new stdClass();
           $objDocumento->identificacao->siglaDaUnidadeProdutora = utf8_encode($parObjDocumentoDTO->getStrSiglaUnidadeGeradoraProtocolo());
-          $objDocumento->identificacao->complemento = $this->objProcessoEletronicoRN->reduzirCampoTexto(utf8_encode($parObjDocumentoDTO->getStrDescricaoUnidadeGeradoraProtocolo()), 100);
+          $objDocumento->identificacao->complemento = utf8_encode($this->objProcessoEletronicoRN->reduzirCampoTexto($parObjDocumentoDTO->getStrDescricaoUnidadeGeradoraProtocolo(), 100));
           $objDocumento->identificacao->numero = utf8_encode($parObjDocumentoDTO->getStrNumero());
           $objDocumento->identificacao->ano = substr($parObjDocumentoDTO->getDtaGeracaoProtocolo(), 6, 4);
       }else if($strStaNumeracao == SerieRN::$TN_SEQUENCIAL_ANUAL_ORGAO){
@@ -1744,7 +1744,7 @@ class ExpedirProcedimentoRN extends InfraRN {
           $objDocumento->identificacao = new stdClass();
           $objDocumento->identificacao->numero = utf8_encode($parObjDocumentoDTO->getStrNumero());
           $objDocumento->identificacao->siglaDaUnidadeProdutora = utf8_encode($objOrgaoDTO->getStrSigla());
-          $objDocumento->identificacao->complemento = $this->objProcessoEletronicoRN->reduzirCampoTexto(utf8_encode($objOrgaoDTO->getStrDescricao()), 100);
+          $objDocumento->identificacao->complemento = utf8_encode($this->objProcessoEletronicoRN->reduzirCampoTexto($objOrgaoDTO->getStrDescricao(), 100));
           $objDocumento->identificacao->ano = substr($parObjDocumentoDTO->getDtaGeracaoProtocolo(), 6, 4);
       }
     }


### PR DESCRIPTION
Exemplo do Erro: SOAP-ERROR: Encoding: string 'Assessoria de Comunicação do Gabinete do Diretor-Presidente da Autoridade Nacional de Proteç\xc3...' is not a valid utf-8 string